### PR TITLE
[Feat] Combines all values for a given subscriber 

### DIFF
--- a/grafana_dashboards/sdcore/5g_network.json
+++ b/grafana_dashboards/sdcore/5g_network.json
@@ -118,13 +118,28 @@
             {
               "options": {
                 "0": {
+                  "color": "red",
+                  "index": 1,
                   "text": "Down"
                 },
                 "1": {
+                  "color": "green",
+                  "index": 0,
                   "text": "Up"
                 }
               },
               "type": "value"
+            },
+            {
+              "options": {
+                "match": "null+nan",
+                "result": {
+                  "color": "red",
+                  "index": 2,
+                  "text": "Down"
+                }
+              },
+              "type": "special"
             }
           ],
           "max": 1,

--- a/grafana_dashboards/sdcore/5g_network.json
+++ b/grafana_dashboards/sdcore/5g_network.json
@@ -91,6 +91,16 @@
         }
       ],
       "title": "5G Active PDU Sessions",
+      "transformations": [
+        {
+          "id": "reduce",
+          "options": {
+            "reducers": [
+              "last"
+            ]
+          }
+        }
+      ],
       "type": "stat"
     },
     {
@@ -246,6 +256,18 @@
                 "value": 144
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "IP Address (last)"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 167
+              }
+            ]
           }
         ]
       },
@@ -322,6 +344,29 @@
               "instance": "",
               "ip": "IP Address",
               "state": "Status"
+            }
+          }
+        },
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "IMSI": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "IP Address": {
+                "aggregations": [
+                  "last"
+                ],
+                "operation": "aggregate"
+              },
+              "Status": {
+                "aggregations": [
+                  "last"
+                ],
+                "operation": "aggregate"
+              }
             }
           }
         }


### PR DESCRIPTION
# Description

This PR includes multiple improvements to the 5G dashboard:
- We used to have different rows if a given subscriber had multiple IP addresses. We now combine all of them in one row and only display the last IP used
- Fixes a bug where the active pdu sessions panel could double if the UPF changed
- The UPF shows as down when it's unreachable

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library