### PR TITLE
chore: ci fails for linting errors

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -21,4 +21,4 @@ jobs:
       - name: Install Grafana Dashboard Linter
         run: go install github.com/grafana/dashboard-linter@latest
       - name: Run Grafana Dashboard Lint
-        run: dashboard-linter lint grafana_dashboards/sdcore/5g_network.json
+        run: dashboard-linter lint grafana_dashboards/sdcore/5g_network.json --strict

--- a/grafana_dashboards/sdcore/5g_network.json
+++ b/grafana_dashboards/sdcore/5g_network.json
@@ -43,6 +43,7 @@
           "color": {
             "mode": "thresholds"
           },
+          "unit": "none",
           "custom": {
             "align": "auto",
             "displayMode": "auto",


### PR DESCRIPTION
# Description

It was the case that the CI wouldn't fail even though there were linting errors. This is addressed by using the `--strict` parameter when running `dashboard-linter`.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library