### PR TITLE
fix: remove pre-assigned uid's to be created automatically on deploy

### DIFF
--- a/grafana_dashboards/sdcore/5g_network.json
+++ b/grafana_dashboards/sdcore/5g_network.json
@@ -683,7 +683,6 @@
   },
   "timepicker": {},
   "timezone": "",
-  "uid": "XpijtYd4z",
   "version": 1,
   "weekStart": ""
 }

--- a/grafana_dashboards/sdcore/5g_network_logs.json
+++ b/grafana_dashboards/sdcore/5g_network_logs.json
@@ -132,7 +132,6 @@
   },
   "timepicker": {},
   "timezone": "",
-  "uid": "Er4Ks25df2",
   "version": 1,
   "weekStart": ""
 }


### PR DESCRIPTION
# Description

This PR aims to enhance dashboard creation by removing pre-existed dashboard UID's. 
The dashboard UID's will be created on deployment.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library